### PR TITLE
Add apply(token: String) helper to OAuthClient companion object

### DIFF
--- a/core/src/main/scala/repatch/github/request/OAuthClient.scala
+++ b/core/src/main/scala/repatch/github/request/OAuthClient.scala
@@ -9,3 +9,7 @@ final case class OAuthClient(token: String, mimes: Seq[MediaType])
     super.httpHeaders ++ Map("Authorization" -> "bearer %s".format(token))
   def mime(ms: Seq[MediaType]): OAuthClient = copy(mimes = ms)
 }
+
+object OAuthClient {
+  def apply(token: String): OAuthClient = OAuthClient(token, MediaType.default)
+}


### PR DESCRIPTION
Adds a convenience helper to create an OAuthClient with default media types with a supplied bearer token.